### PR TITLE
remind: refactor to work more like a queue

### DIFF
--- a/plugins/remind.go
+++ b/plugins/remind.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -68,7 +67,6 @@ func newreminderPlugin(m *seabird.BasicMux, cm *seabird.CommandMux, db *nut.DB) 
 
 func (p *reminderPlugin) joinHandler(b *seabird.Bot, m *irc.Message) {
 	if m.Prefix.Name != b.CurrentNick() {
-		fmt.Println("WE DIDN'T JOIN")
 		return
 	}
 


### PR DESCRIPTION
CC @jsvana 

This improves the remind plugin to read reminders more like a queue, rather than starting up a goroutine for every reminder.