### PR TITLE
Track user modes in channels

### DIFF
--- a/plugins/channel_track.go
+++ b/plugins/channel_track.go
@@ -304,7 +304,7 @@ func (p *ChannelTracker) namesCallback(b *seabird.Bot, m *irc.Message) {
 	}
 
 	channel := m.Params[2]
-	users := strings.Split(m.Trailing(), " ")
+	users := strings.Split(strings.TrimSpace(m.Trailing()), " ")
 	for _, user := range users {
 		i := strings.IndexFunc(user, func(r rune) bool {
 			_, ok := prefixes[r]

--- a/plugins/channel_track.go
+++ b/plugins/channel_track.go
@@ -313,8 +313,8 @@ func (p *ChannelTracker) namesCallback(b *seabird.Bot, m *irc.Message) {
 
 		var userPrefixes string
 		if i != -1 {
-			user = user[i:]
 			userPrefixes = user[:i]
+			user = user[i:]
 		}
 
 		// The bot user should be added via JOIN

--- a/plugins/channel_track.go
+++ b/plugins/channel_track.go
@@ -209,7 +209,8 @@ func (p *ChannelTracker) nickCallback(b *seabird.Bot, m *irc.Message) {
 }
 
 func (p *ChannelTracker) modeCallback(b *seabird.Bot, m *irc.Message) {
-	// We only care about MODE messages where a specific user is changed.
+	// We only care about MODE messages where a specific user is
+	// changed.
 	if len(m.Params) < 3 {
 		return
 	}
@@ -264,7 +265,7 @@ func (p *ChannelTracker) whoCallback(b *seabird.Bot, m *irc.Message) {
 	}
 
 	// Modes starts with H/G for here/gone, so we skip that because we don't
-	// care too much about tracking it.
+	// care too much about tracking it for now.
 	userPrefixes := modes[1:]
 
 	// Clear out the modes and reset them
@@ -275,6 +276,8 @@ func (p *ChannelTracker) whoCallback(b *seabird.Bot, m *irc.Message) {
 	}
 }
 
+// getSymbolToPrefixMapping gets the isupport info from the bot and
+// parses prefix into a mapping of the symbol to the mode
 func (p *ChannelTracker) getSymbolToPrefixMapping(b *seabird.Bot) (map[rune]rune, bool) {
 	logger := b.GetLogger()
 


### PR DESCRIPTION
This does its best to track +o, +v, etc in channels. The main downside to the current situation is that it can only track one mode at a time (if a user has +ov, only +o will usually show up) because I don't have a great way of asking for CAP multi-prefix yet. This *should* just handle it properly when multiprefix is enabled.