### PR TITLE
Build images using drone-ci rather than relying on docker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+pipeline:
+  master:
+    image: plugins/docker
+    repo: belak/seabird
+    dockerfile: Dockerfile
+    tag: latest
+    secrets: [ docker_username, docker_password ]
+    when:
+      branch: master
+      event: push
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 pipeline:
-  master:
+  docker:
     image: plugins/docker
     repo: belak/seabird
     dockerfile: Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.8
+go: '1.10'
 
 before_install:
   - go get github.com/alecthomas/gometalinter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.10
 
 ENV SEABIRD_CONFIG /data/seabird.toml
 VOLUME /data


### PR DESCRIPTION
This will allow builds to be pushed out much faster, as I can control the resources where the images are built.