### PR TITLE
Add support for simple string matching

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -112,7 +112,7 @@ func NewBot(confReader io.Reader) (*Bot, error) {
 		b.log.Logger.Level = logrus.DebugLevel
 	}
 
-	commandMux := NewCommandMux(b.config.Prefix)
+	commandMux := NewCommandMux(b.config.Prefix, true)
 	mentionMux := NewMentionMux()
 
 	b.mux.Event("PRIVMSG", commandMux.HandleEvent)

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/belak/go-seabird
 require (
 	cloud.google.com/go v0.31.0 // indirect
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ChimeraCoder/anaconda v1.0.0
+	github.com/ChimeraCoder/anaconda v2.0.0+incompatible
 	github.com/ChimeraCoder/tokenbucket v0.0.0-20131201223612-c5a927568de7 // indirect
 	github.com/Unknwon/com v0.0.0-20170819223952-7677a1d7c113
+	github.com/agnivade/levenshtein v1.0.2
 	github.com/azr/backoff v0.0.0-20160115115103-53511d3c7330 // indirect
 	github.com/belak/go-ping v0.0.0-20180517230102-86090cc6a4e2
 	github.com/belak/go-plugin v0.1.0

--- a/mux_basic.go
+++ b/mux_basic.go
@@ -33,6 +33,16 @@ func (mux *BasicMux) Event(c string, h HandlerFunc) {
 	mux.m[c] = append(mux.m[c], h)
 }
 
+// eventNames is an internal function for the CommandMux so it can look up the
+// Levenshtein distance between typed commands and actual commands.
+func (mux *BasicMux) eventNames() []string {
+	var ret []string
+	for k := range mux.m {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
 // HandleEvent allows us to be a Handler so we can nest Handlers
 //
 // The BasicMux simply dispatches all the Handler commands as needed

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,10 @@
+package seabird
+
+func minIntSlice(v []int) (m int) {
+	for i, e := range v {
+		if i == 0 || e < m {
+			m = e
+		}
+	}
+	return
+}


### PR DESCRIPTION
```
[15:31:50]  <~belak>	!hel
[15:31:50]  <seabird51>	belak: Did you mean one of the following: get, help, set
[15:31:55]  <~belak>	!stoc
[15:31:55]  <seabird51>	belak: Did you mean one of the following: stock
[15:31:58]  <~belak>	!wea
[15:31:58]  <seabird51>	belak: Did you mean one of the following: asn, cnam, dig, draw, g, get, gi, help, metar, play, rexp, set, taf, uno, wiki
[15:33:44]  <~belak>	!rou
[15:33:44]  <seabird51>	belak: Did you mean one of the following: asn, cnam, coin, color, dig, down, draw, g, get, gi, give, hand, help, issue, karma, math, ping, play, rdns, rexp, rlvl, rrank, set, stock, taf, tiny, uno, whois, wiki
[15:33:47]  <~belak>	!roul
[15:33:47]  <seabird51>	belak: Did you mean one of the following: coin, down, rdns, rexp, rlvl
[15:33:50]  <~belak>	!bang
[15:33:50]  <seabird51>	belak: Did you mean one of the following: asn, dig, g, hand, math, ping, rdns, rrank, taf, tiny, uno
[15:33:55]  <~belak>	!help
[15:33:55]  <seabird51>	Available commands: active, asn, callsign, cnam, coin, color, dig, dnscheck, down, draw, draw_play, forecast, forget, g, get, gi, give, hand, help, history, isearch, issue, karma, math, metar, ping, play, rdns, remind, rexp, rlvl, roulette, rrank, set, stock, taf, tiny, traceroute, uno, weather, whois, wiki. Use !help [command] for more info.
[15:33:59]  <~belak>	!roule
[15:33:59]  <seabird51>	belak: Did you mean one of the following: coin, color, down, forget, give, help, issue, rdns, rexp, rlvl, roulette, rrank, uno
```

I can't decide if I actually like this or not, but it would be one way of fixing #303, though maybe a manual version of that would be more useful.