### PR TITLE
Fix sqlite3 example config

### DIFF
--- a/_extra/config.sample.toml
+++ b/_extra/config.sample.toml
@@ -21,10 +21,12 @@ cmds = [
 ]
 
 plugins = [
+  "db",
   "chance"
 ]
 
 [db]
+driver = "sqlite3"
 filename = "dev.db"
 
 [ctcp]


### PR DESCRIPTION
You need to add these config options locally if you want to use sqlite3.