### PR TITLE
Fix example db config for sqlite3

### DIFF
--- a/_extra/config.sample.toml
+++ b/_extra/config.sample.toml
@@ -27,7 +27,7 @@ plugins = [
 
 [db]
 driver = "sqlite3"
-filename = "dev.db"
+datasource = "dev.db"
 
 [ctcp]
 enablegit = false


### PR DESCRIPTION
`datasource` is what should be used for sqlite3, not `filename`.