### PR TITLE
Add InfluxDB counter submit

### DIFF
--- a/_extra/config.sample.toml
+++ b/_extra/config.sample.toml
@@ -25,6 +25,16 @@ plugins = [
   "chance"
 ]
 
+[influxdb]
+enabled = false
+url = "https://my-influx-url.com"
+database = "my-db"
+precision = "s"
+username = "username"
+password = "password"
+submitinterval = "10s"
+buffersize = 50
+
 [db]
 driver = "sqlite3"
 datasource = "dev.db"

--- a/bot.go
+++ b/bot.go
@@ -281,9 +281,7 @@ func (b *Bot) handler(c *irc.Client, m *irc.Message) {
 	b.mux.HandleEvent(b, r)
 	timer.Done()
 
-	if b.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
-		r.LogTimings(b.log)
-	}
+	r.LogTimings(b.log)
 }
 
 // ConnectAndRun is a convenience function which will pull the

--- a/bot.go
+++ b/bot.go
@@ -281,7 +281,9 @@ func (b *Bot) handler(c *irc.Client, m *irc.Message) {
 	b.mux.HandleEvent(b, r)
 	timer.Done()
 
-	r.LogTimings(b.log)
+	if b.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		r.LogTimings(b.log)
+	}
 }
 
 // ConnectAndRun is a convenience function which will pull the

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/goinvest/iexcloud v0.0.0-20190827121925-77c60293a922
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.1.1
+	github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mlbright/darksky v0.0.0-20190903032611-d133a40b35ab
@@ -36,6 +37,7 @@ require (
 	github.com/zmb3/spotify v0.0.0-20190725171427-5159bf56b13d
 	golang.org/x/net v0.0.0-20190918130420-a8b05e9114ab
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/tools v0.0.0-20191031220737-6d8f1af9ccc0 // indirect
 	googlemaps.github.io/maps v0.0.0-20190909213747-3c037358a0f0
 	gopkg.in/irc.v3 v3.1.0
 	xorm.io/core v0.7.0


### PR DESCRIPTION
This is a completely overengineered (but not yet wholly functioning) PR
to make seabird submit data to InfluxDB.